### PR TITLE
Fixed coordinates for Southern and Western hemispheres

### DIFF
--- a/hcx-to-wigle.sh
+++ b/hcx-to-wigle.sh
@@ -37,6 +37,6 @@ echo "MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,
 
 # Insert values from actual csv
 
-awk 'BEGIN { FS = "\t" } ; { print $3","$4","$5$6","$1" "$2","$9","$10","$15","$16","$20",0,WIFI" }' "$TMPFILE" >> "$FILENAME"
+awk 'BEGIN { FS = "\t" } ; $12=="S" {$15=-$15} $14=="W" {$16=-$16} { print $3","$4","$5$6","$1" "$2","$9","$10","$15","$16","$20",0,WIFI" }' "$TMPFILE" >> "$FILENAME"
 
 rm "$TMPFILE"


### PR DESCRIPTION
WiGLE takes GPS coordinates in DD format (southern and western hemispheres indicated with negative numbers). I have updated the script to convert hcxpcapngtool-provided coordinates.